### PR TITLE
Relax regex for content parsing.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -497,7 +497,7 @@
 
   function parseCommentNode (node) {
     var data;
-    var matches = node.textContent.match(/^\s*(\/?)content\s*([\s\S]*?)\s*$/i);
+    var matches = node.textContent.match(/^ (\/?)content (.*)/i);
 
     if (matches) {
       if (matches[2]) {


### PR DESCRIPTION
I relaxed the regex here since we know which characters we can expect, but since we're parsing both opening and closing content markers here and have to take into account whether there may, or may not, be any JSON data it's cleaner to keep the regex. If at some point performance proves to be an issue (which I doubt) then let's move to a faster parsing algorithm then.