### PR TITLE
Set main field in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "template-html",
   "version": "0.0.0",
   "repository": "https://github.com/yourname/template-html",
+  "main": "dist/template-html.js",
   "dependencies": {},
   "devDependencies": {
     "bower": "latest",


### PR DESCRIPTION
This sets a main field in the package json, so that this can be used by CommonJS bundlers directly.